### PR TITLE
Add support to numpy arays instead of reading a file for the input data

### DIFF
--- a/flagser_binding/__init__.py
+++ b/flagser_binding/__init__.py
@@ -1,1 +1,1 @@
-from .flagser import flagser
+from .flagser import flagser, flagser_file

--- a/flagser_binding/flagser.py
+++ b/flagser_binding/flagser.py
@@ -14,7 +14,7 @@ import os
 from flagser_pybind import compute_homology
 
 
-def flagser(file_data):
+def flagser_file(file_data):
     """Compute persistent homology for directed flag complexes. Important: the
     input graphs cannot contain self-loops. i.e. edges that start and end in
     the same vertex.
@@ -53,6 +53,64 @@ def flagser(file_data):
     args = ['--out', output_file, file_data]
 
     homology = compute_homology(args)
+
+    # Clean the file genereated by flagser library
+    os.remove(output_file)
+
+    # Creating dictionary of returns values
+    graphs = []
+    for dim in homology:
+        ret_dict = {}
+        ret_dict.update({'dgms': dim.get_persistence_diagram()})
+        ret_dict.update({'cell_count': dim.get_cell_count()})
+        ret_dict.update({'betti': dim.get_betti_numbers()})
+        ret_dict.update({'euler': dim.get_euler_characteristic()})
+        graphs.append(ret_dict)
+
+    return graphs
+
+
+def flagser(vertexes, vertices, directed=True):
+    """Compute persistent homology for directed flag complexes. Important: the
+    input graphs cannot contain self-loops. i.e. edges that start and end in
+    the same vertex.
+
+    Parameters
+    ----------
+    vertexes: TODO
+    vertices: TODO
+    directed: if true, computes the directed flag complex. Otherwise it
+    computes the undirected flag
+
+    Returns
+    -------
+    A  list of dictionary holding all of the results of the computation by
+    graphs
+    {
+     'dgms': list (size maxdim) of ndarray (n_pairs, 2)
+        A list of persistence diagrams, one for each dimension less
+        than maxdim. Each diagram is an ndarray of size (n_pairs, 2)
+        with the first column representing the birth time and the
+        second column representing the death time of each pair.
+     'cell_count': list (int)
+        Cell count per dimension
+     'betti': ndarray(int)
+        Betti number computed by dimension
+     'euler': int
+        Euler characteristic
+    }
+    """
+    output_file = 'output_flagser_file'
+
+    # Clean if the file from a precedent run was not deleted
+    if os.path.isfile(output_file):
+        os.remove(output_file)
+
+    # Due to current implementation of flagser, an output file is required.
+    # Because of that, an temporary output file is provided and will be delete
+    # after the completion of `compute_homology
+
+    homology = compute_homology(vertexes, vertices, directed)
 
     # Clean the file genereated by flagser library
     os.remove(output_file)

--- a/tests/test_flagser.py
+++ b/tests/test_flagser.py
@@ -7,9 +7,37 @@ Description: This file contains test to check if flagser works.
 """
 __license__ = "Apache 2.0"
 
-from flagser_binding import flagser
+from flagser_binding import flagser, flagser_file
+import numpy as np
 
-def test_flagser_works():
-    ret = flagser('large-test-data.flag')
+
+def test_flagser_on_file_works():
+    ret = flagser_file('large-test-data.flag')
     assert len(ret) == 1
     assert ret[0]['betti'] == [0, 90999, 378, 0]
+
+
+def test_flagser_works():
+    data_file = 'large-test-data.flag'
+    is_dim0 = True
+    vertices = []
+    # Convert flagser format file to numpy arrays
+    with open(data_file, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if line == 'dim 1':
+                is_dim0 = False
+                continue
+            if line == 'dim 0':
+                continue
+
+            if is_dim0:
+                vertexes = np.asarray(list(map(float, line.split(' '))))
+            else:
+                vertices.append(list(map(float, line.split(' '))))
+
+    vertices = np.asarray(vertices)
+    ret = flagser(vertexes, vertices)
+    assert len(ret) == 1
+    assert ret[0]['betti'] == [0, 90999, 378, 0]
+


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-learn/flagser-pybind/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#2 Instead of passing a file to flagser directly give him the data. This allow to not store any data on disk.

#### What does this implement/fix? Explain your changes.

This PR add support to python bindings for `flagser` to take as input `numpy` arrays. Now instead of taking a file as input with *vertexes* and *vertices*. Both parameters must be provided separately. Also because it was quite straightforward to implement it, the bindings support *directed* and *undirected* flags computation. By default it computes *directed* computation.

#### Any other comments?

* The input description parameters of the python bindings must be updated so that users understand to what each input correspond.
* At the moment the python bindings for the method to compute `flagser` with a file as input, was renamed `flagser_file`. While I completely understand that is not a nice name, I didn't have any better ideas, you're more than welcome to provide a better name :)

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->

Regards,
Julián
